### PR TITLE
Added isSecure field in the winrm settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bgollako/gopsremote
+module github.com/CiscoM31/gopsremote
 
 go 1.15
 

--- a/winrm.go
+++ b/winrm.go
@@ -30,7 +30,7 @@ const (
 
 const (
 	WINRM_HTTP_PORT = 5985
-	CHUNK           = 500
+	CHUNK           = 512
 	SCRIPTSEPARATOR = "\n"
 )
 
@@ -359,7 +359,7 @@ func (w *WinRMClient) copyToTempFile(shellId, script string) (string, error) {
 	filename = resp
 	scriptsArray := strings.Split(script, SCRIPTSEPARATOR)
 	for _, scp := range scriptsArray {
-		if len(scp) < 500 {
+		if len(scp) < CHUNK {
 			resp, exitCode, err = w.executeSingleCmd(fmt.Sprintf("%s\necho '%s' | Decode-Base64 | Out-File -FilePath %s -Append", base64Decode, base64.StdEncoding.EncodeToString([]byte(scp)), filename), shellId)
 		} else {
 			// Processing large script in chunks

--- a/winrm.go
+++ b/winrm.go
@@ -29,6 +29,7 @@ const (
 )
 
 const (
+	WINRM_HTTP_PORT = 5985
 	CHUNK           = 500
 	SCRIPTSEPARATOR = "\n"
 )
@@ -60,6 +61,8 @@ type winrmSettings struct {
 	operationTimeout string
 	// Timeout of each HTTP call made
 	timeout int
+	// Whether the call is http or https
+	isSecure bool
 }
 
 type getEndpointDetails func() endpointDetails
@@ -113,6 +116,13 @@ func Port(num int) winrmSettingsOption {
 	}
 }
 
+func IsSecure(b bool) winrmSettingsOption {
+	return func(ws winrmSettings) winrmSettings {
+		ws.isSecure = b
+		return ws
+	}
+}
+
 func MaxEnvelopeSize(size string) winrmSettingsOption {
 	return func(ws winrmSettings) winrmSettings {
 		ws.maxEnvelopeSize = size
@@ -161,6 +171,7 @@ var defaultWinrmSettings winrmSettings = winrmSettings{
 	maxEnvelopeSize:  "153200",
 	locale:           "en-US",
 	operationTimeout: "PT60.000S",
+	isSecure:         true,
 }
 
 // Creates a new WinRM client
@@ -190,7 +201,11 @@ func NewWinRMClient(details getEndpointDetails, options ...winrmSettingsOption) 
 	for _, o := range options {
 		client.winrmSettings = o(client.winrmSettings)
 	}
-	client.url = fmt.Sprintf("https://%s:%d/wsman", client.ipAddress, client.port)
+	if client.isSecure {
+		client.url = fmt.Sprintf("https://%s:%d/wsman", client.ipAddress, client.port)
+	} else {
+		client.url = fmt.Sprintf("http://%s:%d/wsman", client.ipAddress, client.port)
+	}
 	if client.endpointDetails.auth&NTLM == NTLM {
 		client.client.Transport = ntlmssp.Negotiator{RoundTripper: client.client.Transport}
 	}

--- a/xml_test.go
+++ b/xml_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/bgollako/gopsremote"
+	"github.com/CiscoM31/gopsremote"
 	"github.com/google/uuid"
 )
 


### PR DESCRIPTION
Syncing with https://github.com/aspiremore/gopsremote which is used in saturn as a fork of CiscoM31/gopsremote.

Previously only HTTPS connection to the end point was allowed, https://github.com/aspiremore/gopsremote contains changes allowing HTTP connection to the endpoint by adding a isSecure field in the winrm settings.