### PR TITLE
Empty string will not be written into the file and will be skipped

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -359,6 +359,7 @@ func (w *WinRMClient) copyToTempFile(shellId, script string) (string, error) {
 	filename = resp
 	scriptsArray := strings.Split(script, SCRIPTSEPARATOR)
 	for _, scp := range scriptsArray {
+		scp = strings.TrimSpace(scp)
 		if len(scp) == 0 {
 			continue
 		}

--- a/winrm.go
+++ b/winrm.go
@@ -359,10 +359,13 @@ func (w *WinRMClient) copyToTempFile(shellId, script string) (string, error) {
 	filename = resp
 	scriptsArray := strings.Split(script, SCRIPTSEPARATOR)
 	for _, scp := range scriptsArray {
+		if len(scp) == 0 {
+			continue
+		}
 		if len(scp) < CHUNK {
 			resp, exitCode, err = w.executeSingleCmd(fmt.Sprintf("%s\necho '%s' | Decode-Base64 | Out-File -FilePath %s -Append", base64Decode, base64.StdEncoding.EncodeToString([]byte(scp)), filename), shellId)
 		} else {
-			// Processing large script in chunks
+			// Approximately 2600 bytes can be decoded at a time, hence we are processing the script in chunks
 			j := 0
 			for j < len(scp) {
 				if j+CHUNK < len(scp) {


### PR DESCRIPTION
Problem: If an empty line is provided as a separate PowerShell command in the input then while writing it into the file the decode process will throw error as it is not possible to decode an empty string.

Solution: Skipping the script if it is empty.