### PR TITLE
Added logic to restrict HTTP request redirect

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -194,6 +194,9 @@ func NewWinRMClient(details getEndpointDetails, options ...winrmSettingsOption) 
 					InsecureSkipVerify: true,
 				},
 			},
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return errors.New("HTTP request redirect is not allowed")
+			},
 		},
 	}
 	client.endpointDetails = details()


### PR DESCRIPTION
Endpoints must be unable to access the internal network directly or through redirects.